### PR TITLE
 Choose specific netcat avoiding error in current Ubuntu 24.04 repositories.

### DIFF
--- a/resources/scripts/rootfs/Dockerfile
+++ b/resources/scripts/rootfs/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && \
     traceroute \
     dnsutils \
     tcpdump \
-    netcat \
+    netcat-openbsd \
     ssh \
     sudo \
     man-db \


### PR DESCRIPTION
Latest Ubuntu repositories have more than a single version of netcat. This pins a specific one to avoid errors during rootfs builds for people who run arrakis based on Ubuntu 24.04 while not impacting the regular Ubuntu 22 build at all (works normally, I tested to make sure).